### PR TITLE
updated .gitignore to exclude other configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Jupyter and environment-specific files
+.ipynb_checkpoints/
+.env
+.DS_Store
+.vscode/
+*.log
+
 # C extensions
 *.so
 


### PR DESCRIPTION
This pull request updates the .gitignore file to exclude commonly unwanted files and folders, including:

Python cache files (__pycache__/, *.pyc)

Jupyter notebook checkpoints (.ipynb_checkpoints/)

Virtual environments (.env)

IDE/editor configs (.vscode/, .DS_Store)

Log files (*.log)

This helps keep the repository clean and focused on relevant project code.